### PR TITLE
(Fix): Description view not working in Report #287541

### DIFF
--- a/src/components/theme/Views/InsituReportView.jsx
+++ b/src/components/theme/Views/InsituReportView.jsx
@@ -7,11 +7,11 @@ import './styles.less';
 
 function InsituReportView(props) {
   const { content } = props;
-  const { blocks, file, report_category, ...filteredContent } = content;
-  const descriptionBlockId = Object.keys(blocks || {}).find(
-    (blockId) => blocks?.[blockId]?.['@type'] === 'description',
+  const { file, report_category, ...filteredContent } = content;
+  const descriptionBlockId = Object.keys(content.blocks || {}).find(
+    (blockId) => content.blocks?.[blockId]?.['@type'] === 'description',
   );
-  const descriptionBlockValue = blocks?.[descriptionBlockId]?.value;
+  const descriptionBlockValue = content.blocks?.[descriptionBlockId]?.value;
 
   useEffect(() => {
     const descriptionElement = document.querySelector(

--- a/src/components/theme/Views/InsituReportView.jsx
+++ b/src/components/theme/Views/InsituReportView.jsx
@@ -8,7 +8,7 @@ import './styles.less';
 function InsituReportView(props) {
   const { content } = props;
   const { blocks, file, report_category, ...filteredContent } = content;
-  const descriptionBlockId = Object.keys(blocks||{}).find(
+  const descriptionBlockId = Object.keys(blocks || {}).find(
     (blockId) => blocks?.[blockId]?.['@type'] === 'description',
   );
   const descriptionBlockValue = blocks?.[descriptionBlockId]?.value;

--- a/src/components/theme/Views/InsituReportView.jsx
+++ b/src/components/theme/Views/InsituReportView.jsx
@@ -2,12 +2,16 @@ import React, { useEffect } from 'react';
 import RenderBlocks from '@plone/volto/components/theme/View/RenderBlocks';
 import { Grid, Image, Button } from 'semantic-ui-react';
 import articleLine from '@eeacms/volto-insitu-policy/../theme/themes/assets/images/extras/article-line.svg';
-
+import { serializeNodes } from '@plone/volto-slate/editor/render';
 import './styles.less';
 
 function InsituReportView(props) {
   const { content } = props;
-  const { description, file, report_category, ...filteredContent } = content;
+  const { blocks, file, report_category, ...filteredContent } = content;
+  const descriptionBlockId = (Object.keys(blocks) || []).find(
+    (blockId) => blocks[blockId]?.['@type'] === 'description',
+  );
+  const descriptionBlockValue = blocks?.[descriptionBlockId]?.value;
 
   useEffect(() => {
     const descriptionElement = document.querySelector(
@@ -31,7 +35,9 @@ function InsituReportView(props) {
                 <>
                   <h3>Summary</h3>
                   <p className="documentDescription eea callout">
-                    {content.description}
+                    {descriptionBlockValue
+                      ? serializeNodes(descriptionBlockValue)
+                      : content.description}
                   </p>
                 </>
               )}

--- a/src/components/theme/Views/InsituReportView.jsx
+++ b/src/components/theme/Views/InsituReportView.jsx
@@ -8,8 +8,8 @@ import './styles.less';
 function InsituReportView(props) {
   const { content } = props;
   const { blocks, file, report_category, ...filteredContent } = content;
-  const descriptionBlockId = (Object.keys(blocks) || []).find(
-    (blockId) => blocks[blockId]?.['@type'] === 'description',
+  const descriptionBlockId = Object.keys(blocks||{}).find(
+    (blockId) => blocks?.[blockId]?.['@type'] === 'description',
   );
   const descriptionBlockValue = blocks?.[descriptionBlockId]?.value;
 


### PR DESCRIPTION
https://taskman.eionet.europa.eu/issues/287541
The bug occurs beacause in plone, description is not a SlateJsonField is jut a simple text, and this means that it will save the text like this:
<img width="202" alt="Screenshot 2025-05-09 at 15 33 10" src="https://github.com/user-attachments/assets/41b4e73d-9f67-4a40-be90-5b268c000201" />
In the image "2" is superscript.
This means that if you want to acces the rich text version you need to look at the blocks. 
You can see the same approach in the description block:  https://github.com/eea/volto-description-block/blob/master/src/DescriptionBlock/View.jsx
My solution will look first in the blocks than at the content.description as a fallback